### PR TITLE
Fix order of arguments to assertEquals()

### DIFF
--- a/veracity-java-binding-api/src/test/java/nz/ac/wgtn/veracity/approv/jbind/TestBindings.java
+++ b/veracity-java-binding-api/src/test/java/nz/ac/wgtn/veracity/approv/jbind/TestBindings.java
@@ -18,14 +18,14 @@ public class TestBindings {
     public void testActivityMapping1() throws URISyntaxException {
         Set<URI> activites = Bindings.getActivities("java.sql.DriverManager","getConnection",null);
         assertEquals(1,activites.size());
-        assertEquals(activites.iterator().next(),new URI("https://veracity.wgtn.ac.nz/app-provenance#DBAccess"));
+        assertEquals(new URI("https://veracity.wgtn.ac.nz/app-provenance#DBAccess"), activites.iterator().next());
     }
 
     @Test
     public void testActivityMapping2() throws URISyntaxException {
         Set<URI> activites = Bindings.getActivities("java.sql.PreparedStatement","executeUpdate","()I");
         assertEquals(1,activites.size());
-        assertEquals(activites.iterator().next(),new URI("https://veracity.wgtn.ac.nz/app-provenance#DBWrite"));
+        assertEquals(new URI("https://veracity.wgtn.ac.nz/app-provenance#DBWrite"), activites.iterator().next());
     }
 
     @Test
@@ -39,8 +39,7 @@ public class TestBindings {
     public void testActivityMapping4() throws URISyntaxException {
         Set<URI> activites = Bindings.getActivities("java.sql.ResultSet","getInt","(I)I");
         assertEquals(1,activites.size()); // wrong descriptor !
-        assertEquals(activites.iterator().next(),new URI("https://veracity.wgtn.ac.nz/app-provenance#DBRead"));
-
+        assertEquals(new URI("https://veracity.wgtn.ac.nz/app-provenance#DBRead"), activites.iterator().next());
     }
 
 


### PR DESCRIPTION
Noticed this when I got test failures after playing with the config in `bind-jdbc.json`.